### PR TITLE
Create config.w32

### DIFF
--- a/config.w32
+++ b/config.w32
@@ -1,0 +1,8 @@
+// $Id$ 
+// vim:ft=javascript 
+ 
+ARG_ENABLE("couchdb", "enable couchdb support", "no"); 
+ 
+if (PHP_COUCHDB != "no") { 
+    EXTENSION("couchdb", "couchdb.c"); 
+} 


### PR DESCRIPTION
config.w32 required to build php extension on windows
